### PR TITLE
Added code required to handle Traversable objects

### DIFF
--- a/src/ApcuCache.php
+++ b/src/ApcuCache.php
@@ -162,7 +162,7 @@ class ApcuCache implements CacheInterface
      *
      * @throws ApcuInvalidCacheKeysException
      */
-    private function buildKeyNames($keys)
+    private function buildKeyNames(array $keys)
     {
         return array_map(function ($key) {
             return $this->buildKeyName($key);

--- a/src/Exception/ApcuInvalidCacheKeysException.php
+++ b/src/Exception/ApcuInvalidCacheKeysException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Paillechat\ApcuSimpleCache\Exception;
+
+use Psr\SimpleCache\InvalidArgumentException;
+
+class ApcuInvalidCacheKeysException extends \Exception implements InvalidArgumentException
+{
+    public function __construct()
+    {
+        parent::__construct('Cache keys neither an array nor a Traversable!');
+    }
+}


### PR DESCRIPTION
When using apcu-simple-cache with latest version of PhpSpreadsheet (https://github.com/PHPOffice/PhpSpreadsheet) we're getting this error:

`Fatal error: Uncaught TypeError: Argument 1 passed to Paillechat\ApcuSimpleCache\ApcuCache::assertKeyNames() must be of the type array, object given, called in /var/www/orders/vendor/paillechat/apcu-simple-cache/src/ApcuCache.php on line 124 and defined in /var/www/orders/vendor/paillechat/apcu-simple-cache/src/ApcuCache.php:183 Stack trace: #0 /var/www/orders/vendor/paillechat/apcu-simple-cache/src/ApcuCache.php(124): Paillechat\ApcuSimpleCache\ApcuCache->assertKeyNames(Object(Generator)) #1 /var/www/orders/vendor/phpoffice/phpspreadsheet/src/PhpSpreadsheet/Collection/Cells.php(492): Paillechat\ApcuSimpleCache\ApcuCache->deleteMultiple(Object(Generator)) #2 /var/www/orders/vendor/phpoffice/phpspreadsheet/src/PhpSpreadsheet/Collection/Cells.php(479): PhpOffice\PhpSpreadsheet\Collection\Cells->__destruct() #3 /var/www/orders/vendor/phpoffice/phpspreadsheet/src/PhpSpreadsheet/Worksheet/Worksheet.php(385): PhpOffice\PhpSpreadsheet\Collection\Cells->unsetWorksheetCells() #4 /var/www/orders/vendor/phpoffice/phpspreadsheet/src/ in /var/www/orders/vendor/paillechat/apcu-simple-cache/src/ApcuCache.php on line 183`

It seems that apcu-simple-cache does not work with Traversable objects as defined in PSR-16 (https://www.php-fig.org/psr/psr-16/).

To solve this I've added few checks for object and in the end decided to convert Traversable objects to arrays. I've done this so, because Generators can be traversed only once.